### PR TITLE
fix 統合したマスターブランチが正しく動作するための修正

### DIFF
--- a/api/app/Http/Controllers/Api/UserLocationController.php
+++ b/api/app/Http/Controllers/Api/UserLocationController.php
@@ -16,7 +16,7 @@ class UserLocationController extends Controller
     public function index(Request $request)
     {
         $token = $request->header('X-API-TOKEN'); //tokenを取ってくる
-        $user = User::where('remember_token', '=', $token)->first(); //userの照合 データベースから一致するもの取り出す
+        $user = User::where('token', '=', $token)->first(); //userの照合 データベースから一致するもの取り出す
         $user_location = UserLocation::where('user_id', '=', $user->id)->paginate(10);;//10件だけ取得する
         return $user_location;
     }
@@ -27,7 +27,7 @@ class UserLocationController extends Controller
          * ユーザーを判別
         */
         $token = $request->header('X-API-TOKEN');
-        $user = User::where('remember_token', '=', $token)->first();//userの照合 データベースから一致するもの取り出す
+        $user = User::where('token', '=', $token)->first();//userの照合 データベースから一致するもの取り出す
         $user_location = UserLocation::where('user_id', '=', $user->id)->first();//User_locationsとidを照合
         /*** 
          * requestから来た連想配列から取り出していく
@@ -42,7 +42,7 @@ class UserLocationController extends Controller
     public function update(UserLocationRequest $request)
     {
         $token = $request->header('X-API-TOKEN');//Tokenひろう
-        $user = User::where('remember_token', '=', $token)->first();//tokenに該当するユーザー持ってくる 勉強会のときtoken→今回remember_token
+        $user = User::where('token', '=', $token)->first();//tokenに該当するユーザー持ってくる 勉強会のときtoken→今回remember_token
         $user_location = UserLocation::where('user_id', '=', $user->id)->latest()->first();
         //↑について User_locationsとidを照合 latestでそのひとのcreated at が最新のものを選ぶ first で取り出す
         //whereの前はモデルクラス←モデルクラスはEloquent関連のものでテーブルの単数形

--- a/api/app/Http/Controllers/Api/UserLocationController.php
+++ b/api/app/Http/Controllers/Api/UserLocationController.php
@@ -42,7 +42,7 @@ class UserLocationController extends Controller
     public function update(UserLocationRequest $request)
     {
         $token = $request->header('X-API-TOKEN');//Tokenひろう
-        $user = User::where('token', '=', $token)->first();//tokenに該当するユーザー持ってくる 勉強会のときtoken→今回remember_token
+        $user = User::where('token', '=', $token)->first();//tokenに該当するユーザー持ってくる
         $user_location = UserLocation::where('user_id', '=', $user->id)->latest()->first();
         //↑について User_locationsとidを照合 latestでそのひとのcreated at が最新のものを選ぶ first で取り出す
         //whereの前はモデルクラス←モデルクラスはEloquent関連のものでテーブルの単数形

--- a/api/app/Http/Controllers/Api/UserLocationController.php
+++ b/api/app/Http/Controllers/Api/UserLocationController.php
@@ -28,11 +28,11 @@ class UserLocationController extends Controller
         */
         $token = $request->header('X-API-TOKEN');
         $user = User::where('token', '=', $token)->first();//userの照合 データベースから一致するもの取り出す
-        $user_location = UserLocation::where('user_id', '=', $user->id)->first();//User_locationsとidを照合
         /*** 
          * requestから来た連想配列から取り出していく
         */
-        $user_location = UserLocation::create($request->all());
+        //idはusersテーブルから、他はリクエストからなのでarrayで連想配列に追加
+        $user_location = UserLocation::create($request->all() +array('user_id'=>$user->id));
         return [
             "data" => $user_location
         ];

--- a/api/app/Http/Requests/Api/UserLocationRequest.php
+++ b/api/app/Http/Requests/Api/UserLocationRequest.php
@@ -56,8 +56,7 @@ class UserLocationRequest extends FormRequest
          * リクエストからの値はstring型であり、new Carbonを使うことでobject型に変換している。
          * なぜ上でnew Carbonせず、この下でやっているか→→上でnew Carbonすると addHours(1)がちゃんと加算されないバグが起こるためである。
         */
-        $time_diff = $this->time_diff ?? (new Carbon($start_time))->diffInMinutes(new Carbon($end_time));//時間幅、デフォルト値は終わりの時刻-始まりの時刻(
-        \Log::debug($time_diff);
+        $time_diff = $this->time_diff ?? (new Carbon($start_time))->diffInMinutes(new Carbon($end_time));//時間幅、デフォルト値は終わりの時刻-始まりの時刻
         $this->merge([
             'number_of_people'=>$number_of_people,
             'time_diff'=>$time_diff,

--- a/api/app/Http/Requests/Api/UserLocationRequest.php
+++ b/api/app/Http/Requests/Api/UserLocationRequest.php
@@ -49,12 +49,15 @@ class UserLocationRequest extends FormRequest
                     
         $for_plus_one_hour =new Carbon();
         $end_time = $this->end_time ?? $for_plus_one_hour->addHours(1);//終了時刻 デフォルト値は開始時刻の1時間後
+
         /** 
          * はじめは$end_time = $start_time->addHours(1);としていたがこうすると
          * start_timeまで1時間たされてしまうので別途変数に入れてから操作することにした。
+         * リクエストからの値はstring型であり、new Carbonを使うことでobject型に変換している。
+         * なぜ上でnew Carbonせず、この下でやっているか→→上でnew Carbonすると addHours(1)がちゃんと加算されないバグが起こるためである。
         */
-        $time_diff = $this->time_diff ?? $start_time->diffInMinutes($end_time);//時間幅、デフォルト値は終わりの時刻-始まりの時刻(60)
-
+        $time_diff = $this->time_diff ?? (new Carbon($start_time))->diffInMinutes(new Carbon($end_time));//時間幅、デフォルト値は終わりの時刻-始まりの時刻(
+        \Log::debug($time_diff);
         $this->merge([
             'number_of_people'=>$number_of_people,
             'time_diff'=>$time_diff,

--- a/api/database/seeds/ParksTableSeeder.php
+++ b/api/database/seeds/ParksTableSeeder.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Database\Seeder;
 
-class DatabaseSeeder extends Seeder
+class ParksTableSeeder extends Seeder
 {
     /**
      * Seed the application's database.

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Route;
 | is assigned the "api" middleware group. Enjoy building your API!
 |
 */
+Route::post('/v1/key', 'Api\KeyController@generate');// 端末 API KEY 生成
 
 Route::get('/v1/user', 'Api\UserController@show'); //ユーザー情報取得
 


### PR DESCRIPTION
具体的には
・端末APIKey生成APIのためのルーティングがなかったので追加
・シーダのクラスが他と被っていてシードするコマンドでエラーでたので修正
・userlocationコントローラーでのユーザー照合の変数名を間違えていたので修正
・userlocationコントローラーでuser_idをデータベースに入れれていなかったので修正
・バリデーションのデフォルト値で時間差が正しく取得できるていなかったので修正

未
・公園関連APIのGET /park,GET /park/{id} ←これはまだ未完成のため、チェックはしていません。
・default_number