### PR TITLE
MglMapコンポーネントに渡す変数名を変更

### DIFF
--- a/client/components/Map.vue
+++ b/client/components/Map.vue
@@ -1,45 +1,30 @@
 <template>
   <div class="map">
-    <MglMap :accessToken='accessToken' :mapStyle='mapStyle' :center='defaultCoordinates' :zoom='zoom'>
+    <MglMap :accessToken='accessToken' :mapStyle='mapStyle' :center='center' :minZoom='minzoom'>
       <MglGeolocateControl position="bottom-right" />
-      <MglGeojsonLayer
-        :sourceId="geoJsonSource.id"
-        :source="geoJsonSource"
-        layerId="myLayer"
-        :layer="geoJsonlayer"
-      />
     </MglMap>
   </div>
 </template>
 
 <script>
-//Mapboxのラッパーライブラリをインポート
+// Mapboxのラッパーライブラリをインポート
 import Mapbox from 'mapbox-gl'
-import { MglMap, MglGeolocateControl, MglGeojsonLayer } from 'vue-mapbox'
+import { MglMap, MglGeolocateControl } from 'vue-mapbox'
 
 export default {
   components: {
     MglMap,
-    MglGeolocateControl,
-    MglGeojsonLayer
+    MglGeolocateControl
   },
   data () {
     return {
       accessToken: 'pk.eyJ1Ijoic3luc2NoaXNtbyIsImEiOiJja2E5eHEwbXAweHdyMnlxcjlzMDVjMm56In0.lOPjbTfTjop6jTk58sOhTQ',
       mapStyle: 'mapbox://styles/synschismo/cka9xvauz00w31ilcr6ganv88',
-      zoom: 11,
-      defaultCoordinates: [139.540667, 35.650614],
-      coordinates: [139.540667, 35.650614],
-      geoJsonSource: {
-        // GeoJSON をURLから読み込む方法がわからない
-      },
-      geoJsonLayer: {
-        //...some GeoJSON layer configuration object
-      }
+      minzoom: 11,
+      center: [139.540667, 35.650614]
     }
   },
   created () {
-    // We need to set mapbox-gl library here in order to use it in template
     this.mapbox = Mapbox
   }
 }

--- a/client/components/Map.vue
+++ b/client/components/Map.vue
@@ -1,13 +1,8 @@
 <template>
   <div class="map">
-    <MglMap :accessToken='accessToken' :mapStyle='mapStyle' :center='center' :minZoom='minzoom'>
+    <MglMap :accessToken='accessToken' :mapStyle='mapStyle' :center='center' :zoom='zoom' :minZoom='minzoom'>
       <MglGeolocateControl position="bottom-right" />
-      <MglGeojsonLayer
-        :sourceId="geoJsonSource.features.id"
-        :source="geoJsonSource"
-        layerId="myLayer"
-        :layer="geoJsonlayer"
-      />
+      <MglMarker :coordinates="geojson" color="blue" />
     </MglMap>
   </div>
 </template>
@@ -15,22 +10,22 @@
 <script>
 // Mapboxのラッパーライブラリをインポート
 import Mapbox from 'mapbox-gl'
-import { MglMap, MglGeolocateControl, MglGeojsonLayer } from 'vue-mapbox'
+import { MglMap, MglGeolocateControl, MglMarker } from 'vue-mapbox'
 
 export default {
   components: {
     MglMap,
     MglGeolocateControl,
-    MglGeojsonLayer
+    MglMarker
   },
   data () {
     return {
       accessToken: 'pk.eyJ1Ijoic3luc2NoaXNtbyIsImEiOiJja2E5eHEwbXAweHdyMnlxcjlzMDVjMm56In0.lOPjbTfTjop6jTk58sOhTQ',
       mapStyle: 'mapbox://styles/synschismo/cka9xvauz00w31ilcr6ganv88',
-      minzoom: 11,
+      zoom: 11,
+      minzoom: 4,
       center: [139.540667, 35.650614],
-      geoJsonSource: null,
-      geoJsonLayer: null
+      geojson: null
     }
   },
   async created () {
@@ -41,9 +36,9 @@ export default {
     // GeoJsonの取得
     async fetchGeoJson () {
       // geojsonを取得
-      const geoJsonSource = await this.$axios.$get(`${this.$config.clientUrl}/geojson/tokyo.geojson`)
+      const geojson = await this.$axios.$get(`${this.$config.clientUrl}/geojson/tokyo.geojson`)
       // vueインスタンス内のgeojsonを更新
-      this.geoJsonSource = geoJsonSource
+      this.geojson = geojson.features[0].geometry.coordinates
     }
   }
 }

--- a/client/components/Map.vue
+++ b/client/components/Map.vue
@@ -2,6 +2,12 @@
   <div class="map">
     <MglMap :accessToken='accessToken' :mapStyle='mapStyle' :center='center' :minZoom='minzoom'>
       <MglGeolocateControl position="bottom-right" />
+      <MglGeojsonLayer
+        :sourceId="geoJsonSource.features.id"
+        :source="geoJsonSource"
+        layerId="myLayer"
+        :layer="geoJsonlayer"
+      />
     </MglMap>
   </div>
 </template>
@@ -9,23 +15,36 @@
 <script>
 // Mapboxのラッパーライブラリをインポート
 import Mapbox from 'mapbox-gl'
-import { MglMap, MglGeolocateControl } from 'vue-mapbox'
+import { MglMap, MglGeolocateControl, MglGeojsonLayer } from 'vue-mapbox'
 
 export default {
   components: {
     MglMap,
-    MglGeolocateControl
+    MglGeolocateControl,
+    MglGeojsonLayer
   },
   data () {
     return {
       accessToken: 'pk.eyJ1Ijoic3luc2NoaXNtbyIsImEiOiJja2E5eHEwbXAweHdyMnlxcjlzMDVjMm56In0.lOPjbTfTjop6jTk58sOhTQ',
       mapStyle: 'mapbox://styles/synschismo/cka9xvauz00w31ilcr6ganv88',
       minzoom: 11,
-      center: [139.540667, 35.650614]
+      center: [139.540667, 35.650614],
+      geoJsonSource: null,
+      geoJsonLayer: null
     }
   },
-  created () {
+  async created () {
+    await this.fetchGeoJson()
     this.mapbox = Mapbox
+  },
+  methods: {
+    // GeoJsonの取得
+    async fetchGeoJson () {
+      // geojsonを取得
+      const geoJsonSource = await this.$axios.$get(`${this.$config.clientUrl}/geojson/tokyo.geojson`)
+      // vueインスタンス内のgeojsonを更新
+      this.geoJsonSource = geoJsonSource
+    }
   }
 }
 </script>

--- a/client/pages/geojson.vue
+++ b/client/pages/geojson.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
-    {{ json }}
+    {{ json.features[0].properties.name }}
+    {{ json.features[1].properties.name }}
   </div>
 </template>
 


### PR DESCRIPTION
Map.vueでMglMapに渡している変数名が間違っていた（場合によって動くが不安定）ので、正しい変数名に変更（太字部分）
<MglMap :accessToken='accessToken' :mapStyle='mapStyle' :center='center' :**minZoom**='minzoom'>
